### PR TITLE
Add colorscheme pack; remove redundant ones

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -782,13 +782,10 @@
 "}}}
 
 " color schemes {{{
-  NeoBundle 'altercation/vim-colors-solarized'
-  NeoBundle 'nanotech/jellybeans.vim'
-  NeoBundle 'tomasr/molokai'
+  NeoBundle 'flazz/vim-colorschemes'
   NeoBundle 'chriskempson/vim-tomorrow-theme'
   NeoBundle 'chriskempson/base16-vim'
   NeoBundle 'w0ng/vim-hybrid'
-  NeoBundle 'sjl/badwolf'
   NeoBundle 'jelera/vim-gummybears-colorscheme'
   NeoBundle 'zeis/vim-kolor' "{{{
     let g:kolor_underlined=1


### PR DESCRIPTION
The removed ones are all in the colorscheme pack. I think it makes sense to have many popular colorschemes (which this pack has) to make this appeal more generally.
