### PR TITLE
Add --line-numbers to unite ag opts

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -556,7 +556,7 @@
 
       if executable('ag')
         let g:unite_source_grep_command='ag'
-        let g:unite_source_grep_default_opts='--nocolor --nogroup -S -C4'
+        let g:unite_source_grep_default_opts='--nocolor --line-numbers --nogroup -S -C4'
         let g:unite_source_grep_recursive_opt=''
       elseif executable('ack')
         let g:unite_source_grep_command='ack'


### PR DESCRIPTION
unite.vim needs to be feed line numbers from it's search tool.
By default ag doesn't supply line number. So we add the --line-numbers option.
