### PR TITLE
Add neobundle#begin()/neobundle#end()

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -871,7 +871,6 @@
     let g:kolor_underlined=1
   "}}}
 
-  exec 'colorscheme '.s:settings.colorscheme
 "}}}
 
 " finish loading {{{
@@ -882,6 +881,7 @@
   endif
   call neobundle#end()
   filetype plugin indent on
+  exec 'colorscheme '.s:settings.colorscheme
   syntax enable
   NeoBundleCheck
 "}}}


### PR DESCRIPTION
Replace `neobundle#rc()` by `neobundle#begin` to remove the error message on startup.

But, the second commit is to move the colorscheme, if I didn't do so, vim will notify that no colorscheme named XXXX if I define the colorscheme in `g:dotvim_settings` , so I'm not sure whether replacing `neobundle#rc()`  needs more modification...
