### PR TITLE
Updated zen_html_tab to handle expansions within '<>' as well.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -358,11 +358,10 @@
     NeoBundleLazy 'gregsexton/MatchTag', {'autoload':{'filetypes':['html','xml']}}
     NeoBundleLazy 'mattn/emmet-vim', {'autoload':{'filetypes':['html','xml','xsl','xslt','xsd','css','sass','scss','less','mustache']}} "{{{
       function! s:zen_html_tab()
-        let line = getline('.')
-        if match(line, '<.*>') < 0
-          return "\<c-y>,"
+        if !emmet#isExpandable()
+          return "\<plug>(emmet-move-next)"
         endif
-        return "\<c-y>n"
+        return "\<plug>(emmet-expand-abbr)"
       endfunction
       autocmd FileType xml,xsl,xslt,xsd,css,sass,scss,less,mustache imap <buffer><tab> <c-y>,
       autocmd FileType html imap <buffer><expr><tab> <sid>zen_html_tab()


### PR DESCRIPTION
Tab will expand if expansion is possible, even when the abbreviation is within `<>`.

Also, use `<plug>` instead of hard-coded key.