### PR TITLE
Update Mustache and Handlebars vim plugin

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -354,9 +354,11 @@
     NeoBundleLazy 'othree/html5.vim', {'autoload':{'filetypes':['html']}}
     NeoBundleLazy 'wavded/vim-stylus', {'autoload':{'filetypes':['styl']}}
     NeoBundleLazy 'digitaltoad/vim-jade', {'autoload':{'filetypes':['jade']}}
-    NeoBundleLazy 'juvenn/mustache.vim', {'autoload':{'filetypes':['mustache']}}
+    NeoBundleLazy 'mustache/vim-mustache-handlebars', {'autoload':{'filetypes':['mustache','hbs']}} "{{{
+      autocmd  BufNewFile,BufRead *.mustache,*.hogan,*.hulk,*.hjs,*.handlebars,*.hbs set filetype=html.mustache syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
+    "}}}
     NeoBundleLazy 'gregsexton/MatchTag', {'autoload':{'filetypes':['html','xml']}}
-    NeoBundleLazy 'mattn/emmet-vim', {'autoload':{'filetypes':['html','xml','xsl','xslt','xsd','css','sass','scss','less','mustache']}} "{{{
+    NeoBundleLazy 'mattn/emmet-vim', {'autoload':{'filetypes':['html','xml','xsl','xslt','xsd','css','sass','scss','less','mustache','hbs']}} "{{{
       function! s:zen_html_tab()
         let line = getline('.')
         if match(line, '<.*>') < 0


### PR DESCRIPTION
I noticed that the vim plugin for Mustache currently in vimrc is an older, deprecated plugin. I've updated the plugin's Github repo, and added an autocmd to correctly setup the filetype and syntax for Mustache and Handlebars files.

The autocmd line was directly copied from [here](https://github.com/mustache/vim-mustache-handlebars/blob/master/ftdetect/mustache.vim#L3), although I combined the two lines into a single autocmd because syntax highlighting for Handlebars files was not working otherwise.