### PR TITLE
Update Mustache and Handlebars vim plugin

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -354,9 +354,9 @@
     NeoBundleLazy 'othree/html5.vim', {'autoload':{'filetypes':['html']}}
     NeoBundleLazy 'wavded/vim-stylus', {'autoload':{'filetypes':['styl']}}
     NeoBundleLazy 'digitaltoad/vim-jade', {'autoload':{'filetypes':['jade']}}
-    NeoBundleLazy 'juvenn/mustache.vim', {'autoload':{'filetypes':['mustache']}}
+    NeoBundleLazy 'mustache/vim-mustache-handlebars', {'autoload':{'filetypes':['mustache','handlebars']}}
     NeoBundleLazy 'gregsexton/MatchTag', {'autoload':{'filetypes':['html','xml']}}
-    NeoBundleLazy 'mattn/emmet-vim', {'autoload':{'filetypes':['html','xml','xsl','xslt','xsd','css','sass','scss','less','mustache']}} "{{{
+    NeoBundleLazy 'mattn/emmet-vim', {'autoload':{'filetypes':['html','xml','xsl','xslt','xsd','css','sass','scss','less','mustache','handlebars']}} "{{{
       function! s:zen_html_tab()
         let line = getline('.')
         if match(line, '<.*>') < 0


### PR DESCRIPTION
I noticed that the vim plugin for Mustache currently in vimrc is an older, deprecated plugin. I've updated the plugin's Github repo, and updated the `emmet-vim` plugin to also load for Handlebars files.
