### PR TITLE
Add Fastfold as suggested by NeoComplete

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -662,7 +662,7 @@
     NeoBundle 'kana/vim-vspec'
     NeoBundleLazy 'tpope/vim-scriptease', {'autoload':{'filetypes':['vim']}}
     NeoBundleLazy 'tpope/vim-markdown', {'autoload':{'filetypes':['markdown']}}
-    if executable('redcarpet') && executable('instant-markdown-d')
+    if executable('instant-markdown-d')
       NeoBundleLazy 'suan/vim-instant-markdown', {'autoload':{'filetypes':['markdown']}}
     endif
     NeoBundleLazy 'guns/xterm-color-table.vim', {'autoload':{'commands':'XtermColorTable'}}

--- a/vimrc
+++ b/vimrc
@@ -462,6 +462,10 @@
         let g:neocomplete#enable_at_startup=1
         let g:neocomplete#data_directory=s:get_cache_dir('neocomplete')
       "}}}
+      NeoBundle 'Konfekt/FastFold' "{{{
+        let g:fastfold_savehook = 1
+        let g:fastfold_fold_command_suffixes = []
+      "}}}
     endif "}}}
     if s:settings.autocomplete_method == 'neocomplcache' "{{{
       NeoBundleLazy 'Shougo/neocomplcache.vim', {'autoload':{'insert':1}} "{{{


### PR DESCRIPTION
Current vimrc defaults foldmethod to syntax. This is complained by NeoComplete every time. Add Fastfold as suggested by NeoComplete.

For more information ,see the FAQ from NeoComplete

Q: Freeze for a while and close opened folding when I begin to insert.
https://github.com/Shougo/neocomplcache.vim/issues/368

A: I think you use 'foldmethod' is "expr" or "syntax". It is too heavy to use
neocomplete (or other auto completion.) You should change 'foldmethod'
option or install FastFold plugin.