### PR TITLE
Remove redcarpet as dependency of vim-instant-markdown

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -658,7 +658,7 @@
     NeoBundle 'kana/vim-vspec'
     NeoBundleLazy 'tpope/vim-scriptease', {'autoload':{'filetypes':['vim']}}
     NeoBundleLazy 'tpope/vim-markdown', {'autoload':{'filetypes':['markdown']}}
-    if executable('redcarpet') && executable('instant-markdown-d')
+    if executable('instant-markdown-d')
       NeoBundleLazy 'suan/vim-instant-markdown', {'autoload':{'filetypes':['markdown']}}
     endif
     NeoBundleLazy 'guns/xterm-color-table.vim', {'autoload':{'commands':'XtermColorTable'}}


### PR DESCRIPTION
There is only one npm dependency according to the home page: https://github.com/suan/vim-instant-markdown

Test: vim README.md, verify a tab is shown in the browser for preview.